### PR TITLE
Switch to PointerEvents to support Mobile

### DIFF
--- a/run_0.js
+++ b/run_0.js
@@ -104,18 +104,24 @@ window.addEventListener("resize", () => {
   simulator.resize(canvas.width, canvas.height);
 });
 
-window.addEventListener("mousemove", (e) => {
+window.addEventListener("pointermove", (e) => {
   simulator.mouseX = e.clientX;
   simulator.mouseY = e.clientY;
 });
 
-window.addEventListener("mousedown", (e) => {
+window.addEventListener("pointerdown", (e) => {
+  // Account for first-frame drags (on mobile)
+  simulator.mouseX = e.clientX;
+  simulator.mouseY = e.clientY;
+  simulator.mousePrevX = e.clientY;
+  simulator.mousePrevY = e.clientY;
+
   if (e.button == 0) {
     simulator.drag = true;
   }
 });
 
-window.addEventListener("mouseup", (e) => {
+window.addEventListener("pointerup", (e) => {
   if (e.button == 0) {
     simulator.drag = false;
   }

--- a/run_0.js
+++ b/run_0.js
@@ -110,6 +110,12 @@ window.addEventListener("pointermove", (e) => {
 });
 
 window.addEventListener("pointerdown", (e) => {
+  // Account for first-frame drags (mobile primarily)
+  simulator.mouseX = e.clientX;
+  simulator.mouseY = e.clientY;
+  simulator.mousePrevX = e.clientX;
+  simulator.mousePrevY = e.clientY;
+
   if (e.button == 0) {
     simulator.drag = true;
   }

--- a/run_0.js
+++ b/run_0.js
@@ -110,12 +110,6 @@ window.addEventListener("pointermove", (e) => {
 });
 
 window.addEventListener("pointerdown", (e) => {
-  // Account for first-frame drags (on mobile)
-  simulator.mouseX = e.clientX;
-  simulator.mouseY = e.clientY;
-  simulator.mousePrevX = e.clientY;
-  simulator.mousePrevY = e.clientY;
-
   if (e.button == 0) {
     simulator.drag = true;
   }


### PR DESCRIPTION
@kotsoft `PointerEvents` are the general abstraction between `MouseEvents` and `TouchEvents`, so they'll let mobile devices automagically work.

Since there are no `pointermove` events before touchdown, the previous frame positions need to be set upon `pointerdown` to prevent big jumps in velocity.

